### PR TITLE
0.8.2

### DIFF
--- a/the_blocker_mod/common/buildings/TBM_buildings.txt
+++ b/the_blocker_mod/common/buildings/TBM_buildings.txt
@@ -314,7 +314,7 @@ building_museum_apocalypse = {
 	category = unity
 
 	is_capped_by_modifier = yes
-	base_cap_amount = 0
+	#base_cap_amount = 0
 
 	potential = {
 		NOT = { is_planet_class = pc_habitat }

--- a/the_blocker_mod/common/buildings/TBM_buildings.txt
+++ b/the_blocker_mod/common/buildings/TBM_buildings.txt
@@ -314,13 +314,12 @@ building_museum_apocalypse = {
 	category = unity
 
 	is_capped_by_modifier = yes
+	base_cap_amount = 0
 
 	potential = {
 		NOT = { is_planet_class = pc_habitat }
 		exists = owner
 	}
-
-	base_cap_amount = 1
 
 	resources = {
 		category = planet_buildings
@@ -359,13 +358,12 @@ building_laboratory_apocalypse = {
 	category = research
 
 	is_capped_by_modifier = yes
+	base_cap_amount = 0
 
 	potential = {
 		NOT = { is_planet_class = pc_habitat }
 		exists = owner
 	}
-
-	base_cap_amount = 1
 
 	resources = {
 		category = planet_buildings
@@ -410,7 +408,7 @@ building_cathedral_apocalypse = {
 		exists = owner
 	}
 
-	base_cap_amount = 1
+	base_cap_amount = 0
 
 	resources = {
 		category = planet_buildings

--- a/the_blocker_mod/common/deposits/TBM_custom_features.txt
+++ b/the_blocker_mod/common/deposits/TBM_custom_features.txt
@@ -681,6 +681,7 @@ d_sea_monster = {
 
 	triggered_planet_modifier = {
 		potential = {
+			exists = owner
 			owner = { has_trait = trait_aquatic	}
 		}
 		modifier = {
@@ -690,6 +691,7 @@ d_sea_monster = {
 
 	triggered_planet_modifier = {
 		potential = {
+			exists = owner
 			owner = { has_civic = civic_anglers }
 		}
 		modifier = {
@@ -759,6 +761,7 @@ d_great_lake = {
 	
 	triggered_planet_modifier = {
 		potential = { 
+			exists = owner
 			owner = { 
 				has_civic = civic_anglers 
 			}
@@ -1092,13 +1095,15 @@ d_basaltic_outcrops = {
 		modifier = {
 			factor = 0
 			owner = {
-				has_ai_personality = ruthless_capitalists	# Alloys are profitable!
-				has_ai_personality = hegemonic_imperialists	# We like imposing landscape (and mining)
-				has_civic = civic_mining_guilds
-				has_civic = civic_crafters
-				has_civic = civic_corporate_crafters
-				has_civic = civic_shared_burden
-				has_origin = origin_subterranean
+				OR = {
+					has_ai_personality = ruthless_capitalists	# Alloys are profitable!
+					has_ai_personality = hegemonic_imperialists	# We like imposing landscape (and mining)
+					has_civic = civic_mining_guilds
+					has_civic = civic_crafters
+					has_civic = civic_corporate_crafters
+					has_civic = civic_shared_burden
+					has_origin = origin_subterranean
+				}
 			}
 		}
 	}
@@ -2940,6 +2945,7 @@ d_arid_plains = {
 
 	triggered_planet_modifier = {
 		potential = {
+			exists = owner
 			owner.home_planet = {
 				is_dry = yes
 			}

--- a/the_blocker_mod/common/deposits/TBM_custom_features.txt
+++ b/the_blocker_mod/common/deposits/TBM_custom_features.txt
@@ -135,7 +135,7 @@ d_fjordland = {
 
 		modifier = {
 			set = @base		# These are useful, but they're also space-killers, so get rid of them when we need to
-			root = { colony_type = col_mining }
+			from = { colony_type = col_mining }
 		}
 		modifier = {
 			set = @keep
@@ -309,7 +309,7 @@ d_sandstone_spires = {
 
 		modifier = {
 			set = @keep
-			root = {
+			from = {
 				free_district_slots > 1
 				OR = {
 					colony_type = col_mining
@@ -440,7 +440,7 @@ d_steppe_uplands = {
 
 		modifier = {
 			set = @keep
-			root = {
+			from = {
 				OR = {
 					colony_type = col_rural
 					colony_type = col_generator
@@ -523,7 +523,7 @@ d_glacier_lake = {
 
 		modifier = {
 			set = @keep
-			root = {
+			from = {
 				OR = {
 					colony_type = col_farming
 					free_amenities < 5
@@ -623,7 +623,7 @@ d_giant_tree  = {
 
 		modifier = {
 			set = @keep	# Amenities on resource worlds are good!
-			root = {
+			from = {
 				OR = {
 					colony_type = col_mining
 					colony_type = col_farming
@@ -806,12 +806,12 @@ d_great_lake = {
 
 		modifier = {
 			set = @keep
-			root = { colony_type = col_farming }
+			from = { colony_type = col_farming }
 		}
 
 		modifier = {
 			set = @clear		# Kind of counter-intuitive, but AI will have lots of amenities on urban worlds already.
-			root = { colony_type = col_city }
+			from = { colony_type = col_city }
 		}
 
 		modifier = {
@@ -895,12 +895,12 @@ d_floodplains = {
 
 		modifier = {
 			set = @keep	# Basically clear these unless it's a big farm world.
-			root = { colony_type = col_farming }
+			from = { colony_type = col_farming }
 		}
 
 		modifier = {
 			set = @base	# Unless we need a district AND we have other farming slots available, because these aren't that good and we might need housing, etc.
-			root = {
+			from = {
 				num_free_districts = {
 					type = district_farming
 					value > 0
@@ -969,7 +969,7 @@ d_tidal_marshes = {
 
 		modifier = {
 			set = @keep	# Basically clear these unless it's a big farm or wind world.
-			root = {
+			from = {
 				OR = {
 					colony_type = col_farming
 					colony_type = col_generator
@@ -979,7 +979,7 @@ d_tidal_marshes = {
 
 		modifier = {
 			set = @base	# Unless we need a district AND we have other farming slots available, because these aren't that good and we might need housing, etc.
-			root = {
+			from = {
 				OR = {
 					num_free_districts = {
 						type = district_farming
@@ -1084,12 +1084,12 @@ d_basaltic_outcrops = {
 
 		modifier = {
 			set = @always_keep		# Metallurgist upkeep reduction
-			root = { colony_type = col_foundry }
+			from = { colony_type = col_foundry }
 		}
 
 		modifier = {
 			set = @base
-			root = { colony_type = col_mining }
+			from = { colony_type = col_mining }
 		}
 
 		modifier = {
@@ -1212,7 +1212,7 @@ d_volcanic_island = {
 		modifier = {
 			factor = 0
 			owner = { has_trait = trait_aquatic }
-			root = {
+			from = {
 				NOT = { is_planet_class = pc_ocean }
 			}
 		}
@@ -1276,7 +1276,7 @@ d_volcanic_soil = {
 
 		modifier = {
 			set = @keep
-			root = { colony_type = col_farming }
+			from = { colony_type = col_farming }
 		}
 
 		modifier = {
@@ -1457,12 +1457,12 @@ d_fish_shoals = {
 		modifier = {
 			set = @keep
 			owner = { has_trait = trait_aquatic	}
-			root = { is_homeworld = yes }
+			from = { is_homeworld = yes }
 		}
 
 		modifier = {
 			set = @keep
-			root = { colony_type = col_research }
+			from = { colony_type = col_research }
 		}
 	}
 }
@@ -1538,7 +1538,7 @@ d_tbm_impact_crater = {
 
 		modifier = {
 			set = @keep
-			root = { colony_type = col_mining }
+			from = { colony_type = col_mining }
 		}
 
 		modifier = {
@@ -1637,12 +1637,12 @@ d_frozen_wasteland = {
 
 		modifier = {
 			set = @base 	# This is still a space killer, so we want to clear it soon even on generator worlds.
-			root = { colony_type = col_generator }
+			from = { colony_type = col_generator }
 		}
 
 		modifier = {
 			set = @keep 	# However, keep it if we're on a generator world and we're trying to build more generators
-			root = { 
+			from = { 
 				colony_type = col_generator
 				num_free_districts = {
 					type = district_generator
@@ -1777,7 +1777,7 @@ d_mountain_jungle = {
 
 		modifier = {
 			set = @keep	# Keep it around for research.
-			root = {
+			from = {
 				any_owned_pop = {
 					has_job = colonist
 				}
@@ -1787,7 +1787,7 @@ d_mountain_jungle = {
 
 		modifier = {
 			set = @keep
-			root = {
+			from = {
 				OR = {
 					colony_type = col_research
 					colony_type = col_bureau_spiritualist
@@ -1906,12 +1906,12 @@ d_taiga = {
 
 		modifier = {
 			set = @base	# Will stick around on farm worlds until space is needed.
-			root = { colony_type = col_farming }
+			from = { colony_type = col_farming }
 		}
 
 		modifier = {
 			set = @base
-			root = {
+			from = {
 				any_owned_pop = {
 					has_job = colonist
 				}
@@ -1920,7 +1920,7 @@ d_taiga = {
 
 		modifier = {
 			set = @base
-			root = { colony_type = col_default }
+			from = { colony_type = col_default }
 		}
 
 		modifier = {
@@ -2035,12 +2035,12 @@ d_scrubland = {
 
 		modifier = {
 			set = @base	# Will stick around on farm worlds until space is needed.
-			root = { colony_type = col_farming }
+			from = { colony_type = col_farming }
 		}
 
 		modifier = {
 			set = @base
-			root = {
+			from = {
 				any_owned_pop = {
 					has_job = colonist
 				}
@@ -2049,7 +2049,7 @@ d_scrubland = {
 
 		modifier = {
 			set = @base
-			root = { colony_type = col_default }
+			from = { colony_type = col_default }
 		}
 	}
 }
@@ -2183,7 +2183,7 @@ d_fertile_delta = {
 
 		modifier = {
 			set = @base		# Keep unless industrial/urban, in which case keep until we need a district as it's still a good feature and clearing it has downsides.
-			root = {
+			from = {
 				NOR = {
 					colony_type = col_rural
 					colony_type = col_farming
@@ -2249,7 +2249,7 @@ d_drylands = {
 
 		modifier = {
 			set = @clear
-			root = {
+			from = {
 				NOR = {
 					colony_type = col_rural
 					colony_type = col_generator
@@ -2338,7 +2338,7 @@ d_crags = {
 
 		modifier = {
 			set = @base
-			root = {
+			from = {
 				NOR = {
 					colony_type = col_mining
 					free_amenities < 5
@@ -2438,12 +2438,12 @@ d_dunelands = {
 
 		modifier = {
 			set = @base	# Keep until space needed on generator, otherwise not worth the upkeep.
-			root = { colony_type = col_generator }
+			from = { colony_type = col_generator }
 		}
 
 		modifier = {
 			set = @base
-			root = {
+			from = {
 				OR = {
 					any_owned_pop = {
 						has_job = colonist
@@ -2529,7 +2529,7 @@ d_highland_lake = {
 
 		modifier = {
 			set = @base		# Keep unless industrial/urban, in which case keep until we need a district as it's still a good feature and clearing it has downsides.
-			root = {
+			from = {
 				OR = {
 					colony_type = col_industrial
 					colony_type = col_foundry
@@ -2629,7 +2629,7 @@ d_lakelands = {
 
 		modifier = {
 			set = @base		# Keep unless industrial/urban, in which case keep until we need a district as it's still a good feature and clearing it has downsides.
-			root = {
+			from = {
 				OR = {
 					colony_type = col_industrial
 					colony_type = col_foundry
@@ -2719,7 +2719,7 @@ d_lowland_hills = {
 
 		modifier = {
 			set = @keep
-			root = {
+			from = {
 				OR = {
 					colony_type = col_farming
 					colony_type = col_mining
@@ -2815,12 +2815,12 @@ d_misty_plains = {
 
 		modifier = {
 			set = @keep
-			root = { colony_type = col_farming }
+			from = { colony_type = col_farming }
 		}
 
 		modifier = {
 			set = @always_keep
-			root = { is_planet_class = pc_nuked }	# Mostly for flavor, but can also be more useful for the food on tombs
+			from = { is_planet_class = pc_nuked }	# Mostly for flavor, but can also be more useful for the food on tombs
 		}
 	}
 }
@@ -2898,7 +2898,7 @@ d_salt_flats = {
 
 		modifier = {
 			set = @keep
-			root = { colony_type = col_mining }
+			from = { colony_type = col_mining }
 		}
 
 		modifier = {
@@ -2946,7 +2946,7 @@ d_arid_plains = {
 	triggered_planet_modifier = {
 		potential = {
 			exists = owner
-			owner.home_planet = {
+			owner_species.home_planet = {
 				is_dry = yes
 			}
 		}
@@ -2984,7 +2984,7 @@ d_arid_plains = {
 
 		modifier = {
 			set = @base
-			root = { colony_type = col_generator }
+			from = { colony_type = col_generator }
 		}
 
 		modifier = {
@@ -3159,7 +3159,7 @@ d_sandstone_cliffs = {
 
 		modifier = {
 			set = @keep
-			root = { colony_type = col_mining }
+			from = { colony_type = col_mining }
 		}
 
 		modifier = {
@@ -3242,12 +3242,12 @@ d_highlands = {
 
 		modifier = {
 			set = @keep
-			root = { colony_type = col_mining }
+			from = { colony_type = col_mining }
 		}
 
 		modifier = {
 			set = @keep
-			root = { free_amenities < 5 }
+			from = { free_amenities < 5 }
 		}
 	}
 }
@@ -3303,7 +3303,7 @@ d_rough_plains = {
 
 		modifier = {
 			set = @base	# Clear unless you really need the farming space AND have the amenities covered
-			root = {
+			from = {
 				colony_type = col_farming
 				num_districts = {
 					type = district_farming
@@ -3363,8 +3363,8 @@ d_seaweed_shoals = {
 
 	triggered_planet_modifier = {
 		potential = {
+			exists = owner
 			owner = {
-				exists = owner
 				any_owned_pop = {
 					has_job = colonist
 				}
@@ -3400,12 +3400,12 @@ d_seaweed_shoals = {
 
 		modifier = {
 			set = @keep
-			root = { colony_type = col_farming }
+			from = { colony_type = col_farming }
 		}
 
 		modifier = {
 			set = @always_keep	# Keep for sure if aquatic farm world.
-			root = { colony_type = col_farming }
+			from = { colony_type = col_farming }
 			owner = { has_trait = trait_aquatic }
 		}
 	}
@@ -3473,7 +3473,7 @@ d_gas_vents = {
 
 		modifier = {
 			set = @keep
-			root = { colony_type = col_generator }
+			from = { colony_type = col_generator }
 		}
 	}
 }
@@ -3579,7 +3579,7 @@ d_tbm_crater = {
 
 		modifier = {
 			set = @keep
-			root = { colony_type = col_mining }
+			from = { colony_type = col_mining }
 		}
 	}
 }
@@ -3715,7 +3715,7 @@ d_collapsed_cliffs = {
 
 		modifier = {
 			set = @keep
-			root = { colony_type = col_mining }
+			from = { colony_type = col_mining }
 		}
 	}
 }
@@ -3769,7 +3769,7 @@ d_urban_power_plant = {
 
 		modifier = {
 			set = @keep	# Keep, but only on generator worlds where we're actually getting some benefit.
-			root = {
+			from = {
 				colony_type = col_generator
 				num_assigned_jobs = {
 					job = technician
@@ -3902,7 +3902,7 @@ d_settlement = {
 
 		modifier = {
 			set = @keep
-			root = { free_housing <= 3 }
+			from = { free_housing <= 3 }
 		}
 	}
 }
@@ -3992,7 +3992,7 @@ d_dustbowl = {
 
 		modifier = {
 			set = @keep
-			root = {
+			from = {
 				colony_type = col_mining
 				num_free_districts = {
 					type = district_mining
@@ -4003,7 +4003,7 @@ d_dustbowl = {
 
 		modifier = {
 			set = @keep		# Avoid zapping districts in use. Should mean dustbowls stick around on developed worlds, which is the idea flavor-wise
-			root = {
+			from = {
 				num_free_districts = {
 					type = any
 					value < 1
@@ -4047,7 +4047,7 @@ d_deep_trench = {	# Mostly an art placeholder; does the same thing as homeworld 
 
 		modifier = {
 			set = @always_clear	# Keep as no negative effects but don't block ecu.
-			root = { free_district_slots = 0 }
+			from = { free_district_slots = 0 }
 			owner = { has_ascension_perk = ap_arcology_project }
 		}
 	}
@@ -4210,7 +4210,7 @@ d_coal_bed = {
 
 		modifier = {
 			set = @keep
-			root = { colony_type = col_generator }
+			from = { colony_type = col_generator }
 		}
 	}
 }
@@ -4272,7 +4272,7 @@ d_subterranean_gas_lake = {
 
 		modifier = {
 			set = @keep
-			root = { colony_type = col_generator }
+			from = { colony_type = col_generator }
 		}
 
 		modifier = {
@@ -4351,7 +4351,7 @@ d_oil_fields_at_first_light = {
 
 		modifier = {
 			set = @keep
-			root = { colony_type = col_generator }
+			from = { colony_type = col_generator }
 		}
 	}
 }
@@ -4742,7 +4742,7 @@ d_energy_banks = {
 
 		modifier = {
 			set = @always_clear
-			root = {
+			from = {
 				num_free_districts = {
 					type = any
 					value < 1
@@ -4781,7 +4781,7 @@ d_mineral_stockpiles = {
 
 		modifier = {
 			set = @always_clear
-			root = {
+			from = {
 				num_free_districts = {
 					type = any
 					value < 1
@@ -4820,7 +4820,7 @@ d_food_silos = {
 
 		modifier = {
 			set = @always_clear
-			root = {
+			from = {
 				num_free_districts = {
 					type = any
 					value < 1
@@ -4960,7 +4960,7 @@ d_tbm_active_volcano = {
 
 		modifier = {
 			set = @keep
-			root = {
+			from = {
 				OR = {
 					colony_type = col_generator
 					AND = {

--- a/the_blocker_mod/common/deposits/TBM_homeworld_features.txt
+++ b/the_blocker_mod/common/deposits/TBM_homeworld_features.txt
@@ -204,7 +204,7 @@ d_homeworld_deep_trench = {
 
 		modifier = {
 			set = @clear	# Keep as no negative effects but don't block ecu.
-			root = { free_district_slots = 0 }
+			from = { free_district_slots = 0 }
 			owner = { has_ascension_perk = ap_arcology_project }
 		}
 	}
@@ -531,7 +531,7 @@ d_recycling_processes = {
 
 		modifier = {
 			set = @clear	# Get rid of this when upgrading the assembly facility or capital to save alloy upkeep
-			root = {
+			from = {
 				num_assigned_jobs = {
 					job = replicator
 					value >= 3
@@ -627,7 +627,7 @@ d_gestalt_major_impact_site = {
 
 		modifier = {
 			set = @clear
-			root = {
+			from = {
 				planet_crime > 25
 			}
 		}
@@ -768,7 +768,7 @@ d_homeworld_dustbowl = {
 			}
 			
 			# Do not wreck existing district with it, though
-			planet = {
+			from = {
 				num_free_districts = {
 					type = any
 					value > 1
@@ -1059,7 +1059,7 @@ d_experimental_geothermal_tap = {
 		modifier = {
 			set = @clear
 			years_passed > 30
-			root = {
+			from = {
 				num_free_districts = {
 					type = district_generator
 					value > 1
@@ -1113,7 +1113,7 @@ d_gestlat_experimental_geothermal_tap = {
 		modifier = {
 			set = @clear
 			years_passed > 30
-			root = {
+			from = {
 				num_free_districts = {
 					type = district_generator
 					value > 1
@@ -1711,7 +1711,7 @@ d_homeworld_urban_aeroponics = {
 					value >= 20	# greater because we want this gone if the AI is relying on difficulty bonuses, due to efficiency; if not, it likely needs the flexibility more
 				}
 			}
-			root = {
+			from = {
 				num_assigned_jobs = {
 					job = farmer
 					value > 10
@@ -1761,7 +1761,7 @@ d_homeworld_gestalt_urban_aeroponics = {
 					value >= 20	# greater because we want this gone if the AI is relying on difficulty bonuses, due to efficiency; if not, it likely needs the flexibility more
 				}
 			}
-			root = {
+			from = {
 				num_assigned_jobs = {
 					job = farmer
 					value > 10
@@ -1942,7 +1942,7 @@ d_reclaimed_land = {
 
 		modifier = {
 			set = @keep
-			root = {
+			from = {
 				colony_type = col_farming
 			}
 		}
@@ -2860,7 +2860,7 @@ d_collapsed_superhighway = {
 	}
 
 	on_cleared = {	
-		root = {
+		from = {
 			add_modifier = {
 				modifier = superhighway_engineering
 				years = 5
@@ -2955,7 +2955,7 @@ d_homeworld_scrap_mountain = {
 
 		modifier = {
 			set = @clear
-			root = {
+			from = {
 				num_assigned_jobs = {
 					job = scrap_miner
 					value > 2
@@ -3627,7 +3627,7 @@ d_crop_shares = {
 				}
 			}
 
-			root = {
+			from = {
 				num_assigned_jobs = {
 					job = farmer
 					value > 10
@@ -3675,7 +3675,7 @@ d_outdated_food_equipment = {	# Gestalt Prosperous ag district
 				}
 			}
 
-			root = {
+			from = {
 				num_assigned_jobs = {
 					job = farmer
 					value > 10
@@ -4309,7 +4309,7 @@ d_droid_factory = {
 
 		modifier = {
 			set = @always_clear
-			root = {
+			from = {
 				free_amenities > 10		# AI often struggles with amenity death spirals. Research hit is harsh, but we want to avoid the spiral.
 			}
 		}

--- a/the_blocker_mod/common/deposits/TBM_planetary_deposits_overwrites.txt
+++ b/the_blocker_mod/common/deposits/TBM_planetary_deposits_overwrites.txt
@@ -3262,6 +3262,7 @@ d_submerged_ore_veins = {
 
 	triggered_planet_modifier = {
 		potential = {
+			exists = owner
 			owner = { has_origin = origin_ocean_paradise }
 			is_homeworld = yes
 		}
@@ -4892,6 +4893,7 @@ d_teeming_reef = {
 
 	triggered_planet_modifier = {
 		potential = {
+			exists = owner
 			owner = { has_origin = origin_ocean_paradise }
 			is_homeworld = yes
 		}

--- a/the_blocker_mod/common/deposits/TBM_planetary_deposits_overwrites.txt
+++ b/the_blocker_mod/common/deposits/TBM_planetary_deposits_overwrites.txt
@@ -165,7 +165,7 @@ d_mountain_range = {
 
 		modifier = {
 			set = @base
-			root = {
+			from = {
 				OR = {
 					colony_type = col_mining
 					num_free_districts = {
@@ -282,7 +282,7 @@ d_active_volcano = {
 
 		modifier = {
 			set = @keep
-			root = {
+			from = {
 				OR = {
 					colony_type = col_generator
 					AND = {
@@ -358,7 +358,7 @@ d_dangerous_wildlife_blocker = {
 		
 		# Chance of Xenofauna Attacks
 		# hidden_effect = {
-		# 	planet = {
+		# 	from = {
 		# 		set_timed_planet_flag = {
 		# 			flag = settlement_attacked
 		# 			years = 1
@@ -642,7 +642,7 @@ d_dense_jungle = {
 
 		modifier = {
 			set = @base
-			root = {
+			from = {
 				colony_type = col_farming
 			}
 		}
@@ -1018,7 +1018,7 @@ d_quicksand_basin = {
 
 		modifier = {
 			set = @base
-			root = {
+			from = {
 				OR = {
 					colony_type = col_rural
 					colony_type = col_research
@@ -1028,7 +1028,7 @@ d_quicksand_basin = {
 
 		modifier = {
 			set = @keep
-			root = {
+			from = {
 				colony_type = col_mining
 			}
 			owner = { has_technology = tech_noxious_swamp }
@@ -1134,7 +1134,7 @@ d_noxious_swamp = {
 
 		modifier = {
 			set = @keep
-			root = {
+			from = {
 				any_owned_pop = {
 					has_job = colonist
 				}
@@ -1147,7 +1147,7 @@ d_noxious_swamp = {
 
 		modifier = {
 			set = @keep
-			root = {
+			from = {
 				colony_type = col_research
 			}
 		}
@@ -1266,7 +1266,7 @@ d_massive_glacier = {
 		
 		modifier = {
 			set = @base	# These are pretty good mining features but they're also space-killers, so AI should still clear when it needs to
-			root = {
+			from = {
 				colony_type = col_mining
 			}
 		}
@@ -1357,7 +1357,7 @@ d_radioactive_wasteland = {
 
 		modifier = {
 			set = @keep	# These get very little other reason to be kept around so should still go.
-			root = {
+			from = {
 				any_owned_pop = {
 					has_job = colonist
 				}
@@ -1366,7 +1366,7 @@ d_radioactive_wasteland = {
 
 		modifier = {
 			set = @keep
-			root = {
+			from = {
 				colony_type = col_research
 			}
 		}
@@ -1446,7 +1446,7 @@ d_city_ruins = {
 
 		modifier = {
 			set = @keep
-			root = {
+			from = {
 				colony_type = col_research
 			}
 		}
@@ -1510,7 +1510,7 @@ d_bomb_crater = {
 
 		modifier = {
 			set = @keep
-			root = {
+			from = {
 				OR = {
 					colony_type = col_research
 					colony_type = col_mining
@@ -1589,7 +1589,7 @@ d_arid_highlands = {
 			always = yes
 		}
 		district_generator_max = 1
-		mult = value:district_amount_mastery_of_nature
+		mult = value:natural_desposit_district_amount_multiplier
 	}
 	
 	# From A City of the Desert Chain
@@ -1649,7 +1649,7 @@ d_arid_highlands = {
 
 		modifier = {
 			factor = 0
-			root = {
+			from = {
 				colony_type = col_mining
 			}
 		}
@@ -1663,7 +1663,7 @@ d_arid_highlands = {
 
 		modifier = {
 			factor = 0
-			root = {
+			from = {
 				has_planet_flag = desert_strong
 			}
 		}
@@ -1727,7 +1727,7 @@ d_hot_springs = {
 			always = yes
 		}
 		district_generator_max = 1
-		mult = value:district_amount_mastery_of_nature
+		mult = value:natural_desposit_district_amount_multiplier
 	}
 
 	drop_weight = {
@@ -1769,7 +1769,7 @@ d_hot_springs = {
 
 		modifier = {
 			factor = 0	# Do not clear baths on unity worlds
-			root = {
+			from = {
 				OR = {
 					colony_type = col_bureau
 					colony_type = col_bureau_hive
@@ -1781,7 +1781,7 @@ d_hot_springs = {
 
 		modifier = {
 			factor = 0
-			root = {
+			from = {
 				free_amenities < 10
 			}
 		}
@@ -1844,7 +1844,7 @@ d_rushing_waterfalls = {
 			always = yes
 		}
 		district_generator_max = 1
-		mult = value:district_amount_mastery_of_nature
+		mult = value:natural_desposit_district_amount_multiplier
 	}
 
 	drop_weight = {
@@ -1906,7 +1906,7 @@ d_rushing_waterfalls = {
 		
 		modifier = {
 			factor = 0	# Do not clear waterfalls on unity worlds
-			root = {
+			from = {
 				OR = {
 					colony_type = col_bureau
 					colony_type = col_bureau_hive
@@ -1918,7 +1918,7 @@ d_rushing_waterfalls = {
 
 		modifier = {
 			factor = 0
-			root = {
+			from = {
 				free_amenities < 5
 			}
 		}
@@ -1996,7 +1996,7 @@ d_searing_desert = {
 			always = yes
 		}
 		district_generator_max = 1
-		mult = value:district_amount_mastery_of_nature
+		mult = value:natural_desposit_district_amount_multiplier
 	}
 
 	# From A City of the Desert Chain
@@ -2075,14 +2075,14 @@ d_searing_desert = {
 
 		modifier = {
 			set = @base 	# Slight boost, but this is still a space killer, so we want to clear it soon even on generator worlds.
-			root = {
+			from = {
 				colony_type = col_generator
 			}
 		}
 
 		modifier = {
 			set = @keep 	# However, keep it if we're on a generator world and we're trying to build more generators
-			root = {
+			from = {
 				colony_type = col_generator
 				num_free_districts = {
 					type = district_generator
@@ -2130,7 +2130,7 @@ d_frozen_gas_lake = {
 			always = yes
 		}
 		district_generator_max = 1
-		mult = value:district_amount_mastery_of_nature
+		mult = value:natural_desposit_district_amount_multiplier
 	}
 
 	triggered_planet_modifier = {
@@ -2189,7 +2189,7 @@ d_frozen_gas_lake = {
 		
 		modifier = {
 			factor = 0
-			root = {
+			from = {
 				OR = {
 					colony_type = col_generator
 					colony_type = col_research
@@ -2267,7 +2267,7 @@ d_geothermal_vent = {
 			always = yes
 		}
 		district_generator_max = 1
-		mult = value:district_amount_mastery_of_nature
+		mult = value:natural_desposit_district_amount_multiplier
 	}
 
 	drop_weight = {
@@ -2307,7 +2307,7 @@ d_geothermal_vent = {
 
 		modifier = {
 			factor = 0
-			root = {
+			from = {
 				OR = {
 					colony_type = col_generator
 					colony_type = col_research
@@ -2358,7 +2358,7 @@ d_underwater_vent = {
 			always = yes
 		}
 		district_generator_max = 1
-		mult = value:district_amount_mastery_of_nature
+		mult = value:natural_desposit_district_amount_multiplier
 	}
 
 	triggered_planet_modifier = {
@@ -2438,7 +2438,7 @@ d_underwater_vent = {
 
 		modifier = {
 			set = @clear	
-			root = {
+			from = {
 				NOT = { is_homeworld = yes }
 			}
 			owner = { has_trait = trait_aquatic }
@@ -2446,7 +2446,7 @@ d_underwater_vent = {
 
 		modifier = {
 			set = @base	# Should result in Aquatics treating these as basically normal blockers but only on generator worlds. Otherwise, they want the space.
-			root = {
+			from = {
 				OR = {
 					colony_type = col_generator
 					colony_type = col_research
@@ -2457,7 +2457,7 @@ d_underwater_vent = {
 		modifier = {
 			set = @keep
 			owner = { has_trait = trait_aquatic }
-			root = {
+			from = {
 				NOT = { colony_type = col_city }
 			}
 		}
@@ -2506,7 +2506,7 @@ d_tempestous_mountain = {
 			always = yes
 		}
 		district_generator_max = 1
-		mult = value:district_amount_mastery_of_nature
+		mult = value:natural_desposit_district_amount_multiplier
 	}
 
 	triggered_planet_modifier = {
@@ -2554,7 +2554,7 @@ d_tempestous_mountain = {
 
 		modifier = {
 			factor = 0
-			root = {
+			from = {
 				OR = {
 					colony_type = col_farming
 					colony_type = col_mining
@@ -2626,7 +2626,7 @@ d_veiny_cliffs = {
 			always = yes
 		}
 		district_mining_max = 1
-		mult = value:district_amount_mastery_of_nature
+		mult = value:natural_desposit_district_amount_multiplier
 	}
 
 	drop_weight = {
@@ -2671,7 +2671,7 @@ d_veiny_cliffs = {
 
 		modifier = {
 			set = @keep
-			root = {
+			from = {
 				colony_type = col_mining
 			}
 		}
@@ -2748,7 +2748,7 @@ d_mineral_fields = {
 			always = yes
 		}
 		district_mining_max = 1
-		mult = value:district_amount_mastery_of_nature
+		mult = value:natural_desposit_district_amount_multiplier
 	}
 
 	triggered_planet_modifier = {
@@ -2800,7 +2800,7 @@ d_mineral_fields = {
 
 		modifier = {
 			set = @keep	# These are upper-end mining features as they don't hit amenities
-			root = {
+			from = {
 				colony_type = col_mining
 			}
 		}
@@ -2885,7 +2885,7 @@ d_prosperous_mesa = {
 			always = yes
 		}
 		district_mining_max = 1
-		mult = value:district_amount_mastery_of_nature
+		mult = value:natural_desposit_district_amount_multiplier
 	}
 
 	potential = {
@@ -3010,7 +3010,7 @@ d_ore_rich_caverns = {
 			always = yes
 		}
 		district_mining_max = 1
-		mult = value:district_amount_mastery_of_nature
+		mult = value:natural_desposit_district_amount_multiplier
 	}
 
 	drop_weight = {
@@ -3081,7 +3081,7 @@ d_rich_mountain = {
 			always = yes
 		}
 		district_mining_max = 1
-		mult = value:district_amount_mastery_of_nature
+		mult = value:natural_desposit_district_amount_multiplier
 	}
 
 	triggered_planet_modifier = {
@@ -3142,7 +3142,7 @@ d_rich_mountain = {
 
 		modifier = {
 			set = @keep
-			root = {
+			from = {
 				OR = {
 					colony_type = col_mining
 					colony_type = col_farming
@@ -3276,7 +3276,7 @@ d_submerged_ore_veins = {
 			always = yes
 		}
 		district_mining_max = 1
-		mult = value:district_amount_mastery_of_nature
+		mult = value:natural_desposit_district_amount_multiplier
 	}
 
 	potential = {
@@ -3307,7 +3307,7 @@ d_submerged_ore_veins = {
 
 		modifier = {
 			set = @keep
-			root = {
+			from = {
 				colony_type = col_mining
 			}
 		}
@@ -3348,7 +3348,7 @@ d_lichen_fields = {
 			always = yes
 		}
 		district_farming_max = 1
-		mult = value:district_amount_mastery_of_nature
+		mult = value:natural_desposit_district_amount_multiplier
 	}
 
 	triggered_planet_modifier = {
@@ -3427,7 +3427,7 @@ d_lichen_fields = {
 
 		modifier = {
 			set = @keep
-			root = {
+			from = {
 				colony_type = col_farming
 				is_cold = yes	# Needs to be both, otherwise this feature really isn't worth it
 			}
@@ -3496,7 +3496,7 @@ d_bountiful_plains = {
 			always = yes
 		}
 		district_farming_max = 1
-		mult = value:district_amount_mastery_of_nature
+		mult = value:natural_desposit_district_amount_multiplier
 	}
 	
 	potential = {
@@ -3544,7 +3544,7 @@ d_bountiful_plains = {
 
 		modifier = {
 			set = @keep
-			root = {
+			from = {
 				colony_type = col_farming
 			}
 		}
@@ -3638,7 +3638,7 @@ d_rugged_woods = {
 			always = yes
 		}
 		district_farming_max = 1
-		mult = value:district_amount_mastery_of_nature
+		mult = value:natural_desposit_district_amount_multiplier
 	}
 
 	triggered_planet_modifier = {
@@ -3715,7 +3715,7 @@ d_rugged_woods = {
 
 		modifier = {
 			set = @keep
-			root = {
+			from = {
 				colony_type = col_farming
 			}
 		}
@@ -3800,7 +3800,7 @@ d_green_hills = {
 			always = yes
 		}
 		district_farming_max = 1
-		mult = value:district_amount_mastery_of_nature
+		mult = value:natural_desposit_district_amount_multiplier
 	}
 	
 	triggered_planet_modifier = {
@@ -3926,7 +3926,7 @@ d_forgiving_tundra = {
 			always = yes
 		}
 		district_farming_max = 1
-		mult = value:district_amount_mastery_of_nature
+		mult = value:natural_desposit_district_amount_multiplier
 	}
 	
 	triggered_planet_modifier = {
@@ -3987,7 +3987,7 @@ d_forgiving_tundra = {
 
 		modifier = {
 			set = @keep
-			root = {
+			from = {
 				colony_type = col_farming
 			}
 		}
@@ -4060,7 +4060,7 @@ d_boggy_fens = {
 			always = yes
 		}
 		district_farming_max = 1
-		mult = value:district_amount_mastery_of_nature
+		mult = value:natural_desposit_district_amount_multiplier
 	}
 
 	triggered_planet_modifier = {
@@ -4135,14 +4135,14 @@ d_boggy_fens = {
 
 		modifier = {
 			set = @keep
-			root = {
+			from = {
 				colony_type = col_research
 			}
 		}
 
 		modifier = {
 			set = @clear
-			root = {
+			from = {
 				free_amenities < -10	# Only if we're in crisis here. AIs don't need any more help having planetary revolts.
 			}
 		}
@@ -4188,7 +4188,7 @@ d_nutritious_mudland = {
 			always = yes
 		}
 		district_farming_max = 1
-		mult = value:district_amount_mastery_of_nature
+		mult = value:natural_desposit_district_amount_multiplier
 	}
 
 	drop_weight = {
@@ -4252,7 +4252,7 @@ d_nutritious_mudland = {
 
 		modifier = {
 			set = @keep
-			root = {
+			from = {
 				colony_type = col_farming
 			}
 		}
@@ -4309,7 +4309,7 @@ d_fungal_caves = {
 			always = yes
 		}
 		district_farming_max = 1
-		mult = value:district_amount_mastery_of_nature
+		mult = value:natural_desposit_district_amount_multiplier
 	}
 
 	drop_weight = {
@@ -4479,14 +4479,14 @@ d_lush_jungle = {
 		
 		modifier = {
 			set = @keep
-			root = {
+			from = {
 				colony_type = col_research
 			}
 		}
 
 		modifier = {
 			set = @base
-			root = {
+			from = {
 				colony_type = col_farming
 			}
 		}
@@ -4547,7 +4547,7 @@ d_fertile_lands = {
 			always = yes
 		}
 		district_farming_max = 1
-		mult = value:district_amount_mastery_of_nature
+		mult = value:natural_desposit_district_amount_multiplier
 	}
 
 	drop_weight = {
@@ -4594,7 +4594,7 @@ d_fertile_lands = {
 
 		modifier = {
 			set = @keep
-			root = {
+			from = {
 				colony_type = col_farming
 			}
 		}
@@ -4766,7 +4766,7 @@ d_black_soil = {
 			always = yes
 		}
 		district_farming_max = 1
-		mult = value:district_amount_mastery_of_nature
+		mult = value:natural_desposit_district_amount_multiplier
 	}
 
 	drop_weight = {
@@ -4804,7 +4804,7 @@ d_black_soil = {
 
 		modifier = {
 			set = @keep
-			root = {
+			from = {
 				colony_type = col_farming
 			}
 		}
@@ -4898,7 +4898,7 @@ d_teeming_reef = {
 			is_homeworld = yes
 		}
 		district_farming_max = 1
-		mult = value:district_amount_mastery_of_nature
+		mult = value:natural_desposit_district_amount_multiplier
 
 	}
 
@@ -4985,7 +4985,7 @@ d_teeming_reef = {
 		modifier = {
 			set = @keep
 			owner = { has_trait = trait_aquatic	}
-			root = {
+			from = {
 				is_homeworld = yes
 			}
 		}
@@ -5003,7 +5003,7 @@ d_teeming_reef = {
 
 		modifier = {
 			set = @keep
-			root = {
+			from = {
 				colony_type = col_research
 			}
 		}
@@ -5056,7 +5056,7 @@ d_marvelous_oasis = {
 			always = yes
 		}
 		district_farming_max = 1
-		mult = value:district_amount_mastery_of_nature
+		mult = value:natural_desposit_district_amount_multiplier
 	}
 
 	triggered_planet_modifier = {
@@ -5143,7 +5143,7 @@ d_tropical_island = {
 			always = yes
 		}
 		district_farming_max = 1
-		mult = value:district_amount_mastery_of_nature
+		mult = value:natural_desposit_district_amount_multiplier
 	}
 
 	triggered_planet_modifier = {
@@ -5227,7 +5227,7 @@ d_tropical_island = {
 
 		modifier = {
 			set = @keep
-			root = {
+			from = {
 				colony_type = col_farming
 			}
 		}
@@ -5342,7 +5342,7 @@ d_fungal_forest = {
 		
 		modifier = {
 			set = @keep
-			root = {
+			from = {
 				colony_type = col_research
 			}
 		}
@@ -5374,7 +5374,7 @@ d_fungal_forest = {
 
 		modifier = {
 			set = @base
-			root = {
+			from = {
 				colony_type = col_farming
 			}
 		}
@@ -5502,7 +5502,7 @@ d_buzzing_plains = {
 			always = yes
 		}
 		district_generator_max = 1
-		mult = value:district_amount_mastery_of_nature
+		mult = value:natural_desposit_district_amount_multiplier
 	}
 
 	triggered_planet_modifier = {
@@ -5549,14 +5549,14 @@ d_buzzing_plains = {
 
 		modifier = {
 			set = @keep
-			root = {
+			from = {
 				colony_type = col_generator
 			}
 		}
 
 		modifier = {
 			set = @keep
-			root = {
+			from = {
 				colony_type = col_research
 			}
 		}	
@@ -5602,7 +5602,7 @@ d_mineral_striations = {
 			always = yes
 		}
 		district_mining_max = 1
-		mult = value:district_amount_mastery_of_nature
+		mult = value:natural_desposit_district_amount_multiplier
 	}
 
 	triggered_planet_modifier = {
@@ -5611,7 +5611,7 @@ d_mineral_striations = {
 			owner = { has_trait = trait_aquatic }
 		}
 		district_mining_max = -1
-		mult = value:district_amount_mastery_of_nature
+		mult = value:natural_desposit_district_amount_multiplier
 	}
 
 	drop_weight = {
@@ -5635,14 +5635,14 @@ d_mineral_striations = {
 
 		modifier = {
 			set = @keep
-			root = {
+			from = {
 				colony_type = col_mining
 			}
 		}
 
 		modifier = {
 			set = @keep
-			root = {
+			from = {
 				colony_type = col_research
 			}
 		}
@@ -5671,7 +5671,7 @@ d_natural_farmland = {
 			always = yes
 		}
 		district_farming_max = 1
-		mult = value:district_amount_mastery_of_nature
+		mult = value:natural_desposit_district_amount_multiplier
 	}
 
 	drop_weight = {
@@ -5691,14 +5691,14 @@ d_natural_farmland = {
 
 		modifier = {
 			set = @keep
-			root = {
+			from = {
 				colony_type = col_farming
 			}
 		}
 
 		modifier = {
 			set = @keep
-			root = {
+			from = {
 				colony_type = col_research
 			}
 		}
@@ -5737,7 +5737,7 @@ d_scandinavian_reclamation_sector = {
 			always = yes
 		}
 		district_farming_max = 1
-		mult = value:district_amount_mastery_of_nature
+		mult = value:natural_desposit_district_amount_multiplier
 	}
 
 	potential = {
@@ -5784,7 +5784,7 @@ d_pacific_algae_tracts = {
 			always = yes
 		}
 		district_farming_max = 1
-		mult = value:district_amount_mastery_of_nature
+		mult = value:natural_desposit_district_amount_multiplier
 	}
 
 	potential = {
@@ -5832,7 +5832,7 @@ d_saharan_irrigation_project = {
 			always = yes
 		}
 		district_farming_max = 1
-		mult = value:district_amount_mastery_of_nature
+		mult = value:natural_desposit_district_amount_multiplier
 	}
 
 	potential = {
@@ -5879,7 +5879,7 @@ d_mesopotamian_urban_corridor = {
 			always = yes
 		}
 		district_mining_max = 1
-		mult = value:district_amount_mastery_of_nature
+		mult = value:natural_desposit_district_amount_multiplier
 	}
 
 	potential = {
@@ -5927,7 +5927,7 @@ d_delhi_sprawl = {
 			always = yes
 		}
 		district_generator_max = 1
-		mult = value:district_amount_mastery_of_nature
+		mult = value:natural_desposit_district_amount_multiplier
 	}
 
 	potential = {
@@ -5970,7 +5970,7 @@ d_boswash_metropolitan_axis = {
 			always = yes
 		}
 		district_generator_max = 3
-		mult = value:district_amount_mastery_of_nature
+		mult = value:natural_desposit_district_amount_multiplier
 	}
 
 	potential = {
@@ -6017,7 +6017,7 @@ d_pearl_river_agglomerate = {
 			always = yes
 		}
 		district_generator_max = 3
-		mult = value:district_amount_mastery_of_nature
+		mult = value:natural_desposit_district_amount_multiplier
 	}
 
 	potential = {
@@ -6064,7 +6064,7 @@ d_mauritanian_security_zone = {
 			always = yes
 		}
 		district_mining_max = 1
-		mult = value:district_amount_mastery_of_nature
+		mult = value:natural_desposit_district_amount_multiplier
 	}
 
 	potential = {
@@ -6111,7 +6111,7 @@ d_great_albertan_crater = {
 			always = yes
 		}
 		district_mining_max = 1
-		mult = value:district_amount_mastery_of_nature
+		mult = value:natural_desposit_district_amount_multiplier
 	}
 
 	potential = {

--- a/the_blocker_mod/common/deposits/TBM_post_apoc_features.txt
+++ b/the_blocker_mod/common/deposits/TBM_post_apoc_features.txt
@@ -1385,9 +1385,9 @@ d_memorial_apocalypse = {
 	}
 
 	planet_modifier = {
-		building_museum_apocalypse_max_add = 1
-		building_laboratory_apocalypse_max_add = 1
-		building_cathedral_apocalype_add = 1
+		building_museum_apocalypse_max = 1
+		building_laboratory_apocalypse_max = 1
+		building_cathedral_apocalypse_max = 1
 	}
 
 	potential = {

--- a/the_blocker_mod/common/inline_scripts/tbm_ai_empire_weights.txt
+++ b/the_blocker_mod/common/inline_scripts/tbm_ai_empire_weights.txt
@@ -21,7 +21,7 @@ modifier = {
 			has_ascension_perk = ap_machine_worlds
 		}
 	}
-	root = {
+	from = {
 		num_pops > 40
 		num_districts = {
 			type = district_industrial

--- a/the_blocker_mod/common/inline_scripts/tbm_designation_weights.txt
+++ b/the_blocker_mod/common/inline_scripts/tbm_designation_weights.txt
@@ -1,7 +1,6 @@
 # TBM - AI Planet Designation Archetypes
 
-### this = deposit ###
-### from = planet ###
+### this/root = deposit ###
 ### owner = country ###
 
 # Basic planet designation weighting applied to (almost) every feature.
@@ -14,7 +13,7 @@
 # Unity, research designations - this: planet
 modifier = {
 	set = 0
-	root = {
+	from = {
 		OR = {
 			colony_type = col_bureau
 			colony_type = col_bureau_hive
@@ -46,7 +45,7 @@ modifier = {
 
 modifier = {
 	set = 1
-	root = {
+	from = {
 		OR = {
 			colony_type = col_industrial
 			colony_type = col_foundry

--- a/the_blocker_mod/common/inline_scripts/tbm_post_apoc_industrialization.txt
+++ b/the_blocker_mod/common/inline_scripts/tbm_post_apoc_industrialization.txt
@@ -92,7 +92,7 @@
 		if = {
 			limit = {
 				count_owned_pop = {
-					limit = { has_job = unemployed }
+					limit = { is_unemployed = yes }
 					count > 4
 				}
 			}

--- a/the_blocker_mod/common/script_values/TBM_script_values.txt
+++ b/the_blocker_mod/common/script_values/TBM_script_values.txt
@@ -166,6 +166,7 @@ specialist_ratio = {
 	base = 1
 	complex_trigger_modifier = {
 		trigger = count_owned_pop
+		trigger_scope = planet
 		parameters = {
 			is_pop_category = specialist
 		}
@@ -181,6 +182,7 @@ colonial_food_shipment = {
 	base = 2
 	complex_trigger_modifier = {
 		trigger = num_districts
+		trigger_scope = target		# Situation: POst-Apoc -- New Horizons target = colony
 		parameters = {
 			type = district_farming
 		}
@@ -193,6 +195,7 @@ coop_food_shipment = {
 	base = 3
 	complex_trigger_modifier = {
 		trigger = num_districts
+		trigger_scope = target		# Used in Situation: Post-Apoc: New Horizons; target = colony
 		parameters = {
 			type = district_farming
 		}

--- a/the_blocker_mod/common/scripted_effects/TBM_homeworld_effects.txt
+++ b/the_blocker_mod/common/scripted_effects/TBM_homeworld_effects.txt
@@ -424,7 +424,7 @@ tbm_homeworld_origin_spreads = {
 
 		# Farming - Post-apoc get very little farming: 3 (-3 from vanilla)
 		add_deposit = d_nutrient_rations
-		add_deposit = d_lost_warrens
+		add_deposit = d_lost_warren
 		add_deposit = d_seed_banks
 	}
 

--- a/the_blocker_mod/common/situations/tbm_homeworld_situations.txt
+++ b/the_blocker_mod/common/situations/tbm_homeworld_situations.txt
@@ -85,7 +85,7 @@ post_apocalyptic_new_horizons = {
 		modifier = {
 			desc = sending_food
 			current_situation_approach = send_food
-			add = value:colonial_cohesion_gestalt
+			add = value:colonial_food_shipment
 		}
 
 		modifier = {

--- a/the_blocker_mod/events/TBM_02_events.txt
+++ b/the_blocker_mod/events/TBM_02_events.txt
@@ -931,7 +931,7 @@ planet_event = {
 				location = this
 			}
 		}
-		set_planet_flag = sinkhole_causes
+		set_planet_flag = sinkhole_investigated
 	}
 	
 	option = {
@@ -981,6 +981,7 @@ planet_event = {
 			owner = { is_gestalt = no }
 		}
 		set_planet_flag = occasional_sinkholes
+		remove_planet_flag = sinkhole_investigated
 		add_modifier = {
 			modifier = subterranean_river_cruises
 		}

--- a/the_blocker_mod/events/TBM_HW_post_apoc_events.txt
+++ b/the_blocker_mod/events/TBM_HW_post_apoc_events.txt
@@ -70,7 +70,7 @@ planet_event = {
 		trigger = {
 			owner = { is_hive_empire = no }
 		}
-		desc = tbm_hw.102_desc
+		text = tbm_hw.102_desc
 	}
 
 	immediate = {
@@ -169,7 +169,7 @@ planet_event = {
 	}
 
 	trigger = {
-		owner = { has_planet_flag = environmental_remediation_scoring }
+		has_planet_flag = environmental_remediation_scoring
 	}
 
 	immediate = {
@@ -697,7 +697,7 @@ planet_event = {
 					}
 				}
 			}
-			set_country_flag = cultural_restoration
+			owner = { set_country_flag = cultural_restoration }
 			add_modifier = {
 				modifier = cultural_restoration_planet
 				days = -1
@@ -713,7 +713,7 @@ planet_event = {
 
 	### Main clean-up handled here
 	after = {
-		end_event_chain = tbm_environmental_remediation
+		owner = { end_event_chain = tbm_environmental_remediation }
 		set_planet_flag = post_apoc_environmental_restoration
 	}
 }
@@ -1186,7 +1186,7 @@ situation_event = {
 			owner = { is_machine_empire = yes }
 			event_target:post_apoc_homeworld = {
 				NOT = {
-					has_modiifer = malnutrition
+					has_modifier = malnutrition
 				}
 			}
 		}

--- a/the_blocker_mod/events/TBM_handler_events.txt
+++ b/the_blocker_mod/events/TBM_handler_events.txt
@@ -884,7 +884,8 @@ planet_event = {
 	immediate = {
 		if = {
 			limit = {
-				NOT = { has_planet_flag = sinkhole_causes } # Prevents firing the event to give the project when you already have it.
+				has_planet_flag = sinkhole_causes # Prevents firing the event to give the project when you already have it.
+				NOT = { has_planet_flag = sinkhole_investigated }
 				
 				# And only fire Sinkhole Causes after we've seen a couple sinkholes
 				check_variable = {
@@ -919,6 +920,10 @@ planet_event = {
 					modifier = {
 						factor = 0.5 	# Less common if you've chosen to live with them; I have a heart
 						has_planet_flag = occasional_sinkholes
+					}
+					modifier = {
+						factor = 0
+						has_planet_flag = sinkhole_investigated
 					}
 					
 					planet_event = {

--- a/the_blocker_mod/localisation/english/tbm_events_l_english.yml
+++ b/the_blocker_mod/localisation/english/tbm_events_l_english.yml
@@ -8,7 +8,7 @@
  # Pioneering Colonists
 
  tbm_handler.101.name:0 "Pioneering Colonists"
- tbm_handler.101.desc:0 "The colonists who landed on [planet.GetName] have been greeted with a strange and  wonderful alien landscape. Though the new world offers much bounty, even more work lies ahead to prepare land for the cities and industry that will one day make [planet.GetName] a crucial part of the [planet.GetOwnerName].\n\nFortunately, our colonists were hand-picked for their hardiness, ingenuity, and courage in the face of the challenge ahead. They have spent the past months on-world setting up camps, charting the [olanet.GetPlanetMoon] geography, and documenting alien life in detail.\n\nAll that remains is to allocate resources and equipment to begin clearing land to make [planet.GetName] into a new home."
+ tbm_handler.101.desc:0 "The colonists who landed on §Y[planet.GetName]§! have been greeted with a strange and  wonderful alien landscape. Though the new world offers much bounty, even more work lies ahead to prepare land for the cities and industry that will one day make [planet.GetName] a crucial part of the [planet.GetOwnerName].\n\nFortunately, our colonists were hand-picked for their hardiness, ingenuity, and courage in the face of the challenge ahead. They have spent the past months on-world setting up camps, charting the [olanet.GetPlanetMoon] geography, and documenting alien life in detail.\n\nAll that remains is to allocate resources and equipment to begin clearing land to make [planet.GetName] into a new home."
  tbm_handler.101.option:0 "Good luck, brave colonists."
 
 

--- a/the_blocker_mod/localisation/english/tbm_homeworld_features_l_english.yml
+++ b/the_blocker_mod/localisation/english/tbm_homeworld_features_l_english.yml
@@ -36,7 +36,7 @@
  d_computerized_extraction_sites:0 "Computerized Extraction Sites"
  d_computerized_extraction_sites_desc:0 " Originally built before the machine achieved consciousness, these primitive artificial intelligences were purpose-built to efficiently extract ore. Though crude, they have fuelled much of the machine's expansion into space."
 
- d_tbm_strip_mine:0 "Strip Mines"
+ d_tbm_strip_mine:0 "£blocker£ Strip Mines"
  d_tbm_strip_mine_desc:0 "This massive eyesore is a remnant of the industrialization that propelled us into the Space Age. Now mostly a target for criminals and environmental activisists, some mining concerns cling to old practices to make a quick profit."
 
  d_tbm_gestalt_strip_mine:0 "Strip Mines"

--- a/the_blocker_mod/localisation/english/tbm_l_english.yml
+++ b/the_blocker_mod/localisation/english/tbm_l_english.yml
@@ -72,8 +72,8 @@
 
  mod_planet_building_cost_mult:0 "§Y£building£ Building Cost§!"
  
- tbm_unity_colonial_building_scale:0 "\n\n§YAs colonial population grows, frontier infrastructure will exert more and more strain on national cohesion, increasing its $r_unity$ Upkeep.§!"
- tbm_buildings_colonial_infrastructure_tooltip:0 "\n\nColonial infrastructure buildings cannot be built after a planet has consolidated into a single capital region under a §CPlanetary Capital§Y or equivalent. Any existing buildings will fall into disrepair due to being too far from the seat of local power.§!"
+ tbm_unity_colonial_building_scale:0 "\n§YAs colonial population grows, frontier infrastructure will exert more and more strain on national cohesion, increasing its $r_unity$ Upkeep.§!"
+ tbm_buildings_colonial_infrastructure_tooltip:0 "\nColonial infrastructure buildings cannot be built after a planet has consolidated into a single capital region under a §CPlanetary Capital§Y or equivalent. Any existing buildings will fall into disrepair due to being too far from the seat of local power.§!"
 
  building_xeno_synaptic_node:0 "Xeno-Synaptic Node"
  building_xeno_synaptic_node_desc:0 "Directly connected to the Consciousness, this node receives, transmits, and analyzes signals from off-world drones and sensory infrastructure to adjust the gestalt's research and development of new colonization technology.\n\n§CThe complex technology underpinning a functioning §Y£building£ Xeno-Synaptic Node§C requires significant upkeep, but will produce £research£ §CResearch§! for many £blocker_yellow£ §YNatural Blockers§! on this world."
@@ -121,6 +121,8 @@
  # TBM Job Modifiers
 
  mod_pop_category_workers_produces_mult:0 "Resources from $pop_cat_worker_plural$"
+ mod_pop_category_workers_minerals_upkeep_add:0 "$r_minerals$ Upkeep for £pop_cat_worker£ $pop_cat_worker_plural$"
+ 
 
  mod_planet_jobs_workers_food_upkeep_mult:0 "$r_food$ Upkeep for $pop_cat_worker_plural$"
  mod_planet_jobs_specialist_food_upkeep_mult:0 "$r_food$ Upkeep for $pop_cat_specialist_plural$"
@@ -129,9 +131,12 @@
 
  mod_planet_colonist__produces_mult:0 "Resources from $icon_job_colonists$" 
 
- mod_planet_colonist_food_produces_add:0 "£food£ Food from £colonist£ Colonists"
+ mod_planet_colonist_food_produces_add:0 "$r_food$ from $icon_job_colonists$"
+ mod_planet_colonist_food_produces_mult:0 "$r_food$ from $icon_job_colonists$"
  mod_planet_colonist_minerals_produces_add:0 "$r_minerals$ from $icon_job_colonists$"
+ mod_planet_colonist_minerals_produces_mult:0 "$r_minerals$ from $icon_job_colonists$"
  mod_planet_colonist_energy_produces_add:0 "$r_energy$ from $icon_job_colonists$"
+ mod_planet_colonist_energy_produces_mult:0 "$r_energy$ from $icon_job_colonists$"
  mod_planet_colonist_physics_research_produces_add:0 "$r_physics_research$ from $icon_job_colonists$"
  mod_planet_colonist_society_research_produces_add:0 "$r_society_research$ from $icon_job_colonists$"
  mod_planet_colonist_engineering_research_produces_add:0 "$r_engineering_research$ from $icon_job_colonists$"
@@ -163,6 +168,8 @@
  mod_planet_technician_alloys_upkeep_add:0 "$r_alloys$ Upkeep for $job_technician_plural$"
  mod_planet_technician_consumer_goods_produces_add:0 "$r_consumer_goods$ from $job_technician_plural$"
 
+ mod_planet_scrap_miners_alloys_produces_add:0 "r_alloys$ from Scrap Miners"
+
  mod_planet_researchers_food_upkeep_add:0 "$r_food$ Upkeep for $job_researcher_plural$"
  mod_planet_researchers_minerals_upkeep_add:0 "$r_minerals$ Upkeep for $job_researcher_plural$"
  
@@ -172,6 +179,8 @@
  mod_planet_pop_assemblers_alloys_upkeep_mult:0 "Pop Assembly $r_alloys$ Cost"
  mod_planet_pop_assemblers_energy_upkeep_mult:0 "Pop Assembly $r_energy$ Cost"
  mod_planet_pop_assemblers_minerals_upkeep_mult:0 "Pop Assembly $r_minerals$ Cost"
+
+ mod_planet_metallurgists_unity_produces_add:0 "$r_unity$ from $job_metallurgist_plural$"
 
  mod_planet_soldiers_alloys_produces_add:0 "$r_alloys$ from $job_soldier_plural$"
  

--- a/the_blocker_mod/localisation/english/tbm_l_english.yml
+++ b/the_blocker_mod/localisation/english/tbm_l_english.yml
@@ -67,6 +67,9 @@
  r_engineering_research:0 "§Y£engineering_research£ Engineering Research§!"
  r_unity:0 "§Y£unity£ Unity§!"
 
+ planet_colonist:0 "Colonists"
+ planet_scrap_miners:0 "Scrap Miners"
+
 
  # TBM Buildings
 
@@ -123,7 +126,6 @@
  mod_pop_category_workers_produces_mult:0 "Resources from $pop_cat_worker_plural$"
  mod_pop_category_workers_minerals_upkeep_add:0 "$r_minerals$ Upkeep for £pop_cat_worker£ $pop_cat_worker_plural$"
  
-
  mod_planet_jobs_workers_food_upkeep_mult:0 "$r_food$ Upkeep for $pop_cat_worker_plural$"
  mod_planet_jobs_specialist_food_upkeep_mult:0 "$r_food$ Upkeep for $pop_cat_specialist_plural$"
  mod_planet_jobs_exotic_gases_upkeep_mult:0 "$r_exotic_gases$ from Jobs"

--- a/the_blocker_mod/localisation/english/tbm_l_english.yml
+++ b/the_blocker_mod/localisation/english/tbm_l_english.yml
@@ -182,7 +182,7 @@
  mod_planet_pop_assemblers_energy_upkeep_mult:0 "Pop Assembly $r_energy$ Cost"
  mod_planet_pop_assemblers_minerals_upkeep_mult:0 "Pop Assembly $r_minerals$ Cost"
 
- mod_planet_metallurgists_unity_produces_add:0 "$r_unity$ from $job_metallurgist_plural$"
+ mod_planet_metallurgists_unity_produces_add:0 "$r_unity$ from $job_foundry_plural$"
 
  mod_planet_soldiers_alloys_produces_add:0 "$r_alloys$ from $job_soldier_plural$"
  
@@ -201,6 +201,10 @@
  mod_job_dangerous_wildlife_poacher_add:0 "$job_dangerous_wildlife_poacher$ Jobs"
 
  mod_edicts_unity_upkeep_mult:0 "Edict £unity£ Upkeep"
+
+ mod_building_museum_apocalypse_max:0 "Museum of the Apocalypse"
+ mod_building_laboratory_apocalypse_max:0 "Laboratory of Survival"
+ mod_building_cathedral_apocalypse_max:0 "Cathedral of the Fall"
 
  ###
 


### PR DESCRIPTION
Various Bugs Fixed

- Fixed a logic problem that was preventing the Sinkhole Causes event from firing, leading to an ETERNTY OF SINKHOLES.
- Fixed a variety of errors with AI scripts, which should improve AI blocker consideration and also cut down substantially on error log entries
- Added economic category loc for Colonists and Scrap Miners
- Post-apoc special buildings (not fully implemented yet) are no longer available for all empires from game start
- Lost Warrens should now spawn correctly for hive post-apocalyptic
- Fixed several missed existence checks in feature scripts, which should cut down on errors logged
- Fixed a bug in post-apoc environmental checks
- Fixed several scope checks causing errors in script values, mostly relating to WIP situations; mod situations now list their target in script comments
- Added a missing OR in AI feature handling
- Fixed some scope errors in Post-Apoc environmental remediation
- Homeworld Strip Mines now have the correct blocker icon
- Various loc fixes